### PR TITLE
Use configuration for anonymous quotes and Mage 0 customer ID

### DIFF
--- a/app/code/community/Aoe/QuoteCleaner/Model/Cleaner.php
+++ b/app/code/community/Aoe/QuoteCleaner/Model/Cleaner.php
@@ -38,7 +38,10 @@ class Aoe_QuoteCleaner_Model_Cleaner {
 		$report['customer']['duration'] = time() - $startTime;
 		Mage::log('[QUOTECLEANER] Cleaning old customer quotes (duration: '.$report['customer']['duration'].', row count: '.$report['customer']['count'].')');
 
-		// anonymous quotes$startTime = time();
+		// anonymous quotes
+                $olderThan = intval(Mage::getStoreConfig('clean_anonymous_quotes_older_than'));
+                $olderThan = max($olderThan, 7);
+                $startTime = time();
 		$sql = sprintf('DELETE FROM %s WHERE ISNULL(customer_id) AND updated_at < DATE_SUB(Now(), INTERVAL %s DAY) LIMIT %s',
 			$tableName,
 			$olderThan,

--- a/app/code/community/Aoe/QuoteCleaner/Model/Cleaner.php
+++ b/app/code/community/Aoe/QuoteCleaner/Model/Cleaner.php
@@ -28,7 +28,7 @@ class Aoe_QuoteCleaner_Model_Cleaner {
 
 		// customer quotes
 		$startTime = time();
-		$sql = sprintf('DELETE FROM %s WHERE NOT ISNULL(customer_id) AND updated_at < DATE_SUB(Now(), INTERVAL %s DAY) LIMIT %s',
+		$sql = sprintf('DELETE FROM %s WHERE (NOT ISNULL(customer_id) AND customer_id != 0) AND updated_at < DATE_SUB(Now(), INTERVAL %s DAY) LIMIT %s',
 			$tableName,
 			$olderThan,
 			$limit
@@ -42,7 +42,7 @@ class Aoe_QuoteCleaner_Model_Cleaner {
                 $olderThan = intval(Mage::getStoreConfig('clean_anonymous_quotes_older_than'));
                 $olderThan = max($olderThan, 7);
                 $startTime = time();
-		$sql = sprintf('DELETE FROM %s WHERE ISNULL(customer_id) AND updated_at < DATE_SUB(Now(), INTERVAL %s DAY) LIMIT %s',
+		$sql = sprintf('DELETE FROM %s WHERE (ISNULL(customer_id) OR customer_id = 0) AND updated_at < DATE_SUB(Now(), INTERVAL %s DAY) LIMIT %s',
 			$tableName,
 			$olderThan,
 			$limit


### PR DESCRIPTION
Hi,

there are two changes:
- the cleanup for anonymous quotes does not use the config value
- Mage creates quotes with the customer id 0 for anonymous quotes

Best
Thomas
